### PR TITLE
Add server-side search functionality for better performance

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
+import { AdvocatesResponse } from "../../../types/advocate";
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const { searchParams } = new URL(request.url);
+    const searchTerm = searchParams.get("search")?.toLowerCase() || "";
 
-  const data = advocateData;
+    // Uncomment this line to use a database
+    // const data = await db.select().from(advocates);
 
-  return Response.json({ data });
+    let data = advocateData;
+
+    // Server-side filtering for better performance
+    if (searchTerm) {
+      data = data.filter((advocate) => {
+        return (
+          advocate.firstName.toLowerCase().includes(searchTerm) ||
+          advocate.lastName.toLowerCase().includes(searchTerm) ||
+          advocate.city.toLowerCase().includes(searchTerm) ||
+          advocate.degree.toLowerCase().includes(searchTerm) ||
+          advocate.specialties.some((specialty) =>
+            specialty.toLowerCase().includes(searchTerm)
+          ) ||
+          advocate.yearsOfExperience.toString().includes(searchTerm)
+        );
+      });
+    }
+
+    const response: AdvocatesResponse = { data };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error("Error fetching advocates:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch advocates" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/types/advocate.ts
+++ b/src/types/advocate.ts
@@ -1,0 +1,19 @@
+export interface Advocate {
+  id?: number;
+  firstName: string;
+  lastName: string;
+  city: string;
+  degree: string;
+  specialties: string[];
+  yearsOfExperience: number;
+  phoneNumber: number;
+  createdAt?: string;
+}
+
+export interface AdvocatesResponse {
+  data: Advocate[];
+}
+
+export interface SearchFilters {
+  searchTerm: string;
+}


### PR DESCRIPTION
I shifted the advocate search over to the backend 

How it works

/api/advocates?search=term now filters on the server. Errors during search are caught and shown nicely

Why

Browser does less heavy lifting, network traffic only carries what you actually need

This lays the groundwork for real database integration (with proper indexes), pagination controls, and even fancier filters down the road. 